### PR TITLE
[Git Pull request] Remove unused and confusing default broker url

### DIFF
--- a/simple-consumer/README.md
+++ b/simple-consumer/README.md
@@ -22,12 +22,8 @@ Run this command:
 
 	> mvn exec:java
 
-You should see console messages that show the producer connected using the URL
-
-	discovery:(fabric:mq-west)
-
 <!-- 
-  Another way to figure out which container is currently the master is to
+  A way to figure out which container is currently the master is to
   inspect the logs:
 
   cat instances/MQ-West1/data/log/karaf.log | grep mq-fabric

--- a/simple-consumer/src/main/java/org/fusebyexample/mq_fabric_client/simple/SimpleConsumer.java
+++ b/simple-consumer/src/main/java/org/fusebyexample/mq_fabric_client/simple/SimpleConsumer.java
@@ -31,14 +31,8 @@ public class SimpleConsumer {
     private static final String CONNECTION_FACTORY_NAME = "myJmsFactory";
     private static final String DESTINATION_NAME = "queue/simple";
     private static final int MESSAGE_TIMEOUT_MILLISECONDS = 120000;
-    private static final String DEFAULT_BROKER_URL = "discovery:(fabric:default)";
 
     public static void main(String args[]) {
-        final String brokerUrl = System.getProperty("java.naming.provider.url", DEFAULT_BROKER_URL);
-
-        LOG.info("******************************");
-        LOG.info("Connecting to JBoss A-MQ Broker using URL: {}", brokerUrl);
-        LOG.info("******************************");
 
         Connection connection = null;
 

--- a/simple-producer/README.md
+++ b/simple-producer/README.md
@@ -22,12 +22,8 @@ After the consumer is running, run this command:
 
 	> mvn exec:java
 
-You should see console messages that show the producer connected using the URL
-
-	discovery:(fabric:mq-east)
-
 <!--
-  Another way to figure out which container is currently the master is to
+  A way to figure out which container is currently the master is to
   inspect the logs:
 
   cat instances/MQ-East1/data/log/karaf.log | grep mq-fabric

--- a/simple-producer/src/main/java/org/fusebyexample/mq_fabric_client/simple/SimpleProducer.java
+++ b/simple-producer/src/main/java/org/fusebyexample/mq_fabric_client/simple/SimpleProducer.java
@@ -33,14 +33,8 @@ public class SimpleProducer {
     private static final int NUM_MESSAGES_TO_BE_SENT = 1000;
     private static final String CONNECTION_FACTORY_NAME = "myJmsFactory";
     private static final String DESTINATION_NAME = "queue/simple";
-    private static final String DEFAULT_BROKER_URL = "discovery:(fabric:default)";
 
     public static void main(String args[]) {
-        final String brokerUrl = System.getProperty("java.naming.provider.url", DEFAULT_BROKER_URL);
-
-        LOG.info("******************************");
-        LOG.info("Connecting to JBoss A-MQ Broker using URL: {}", brokerUrl);
-        LOG.info("******************************");
 
         Connection connection = null;
 


### PR DESCRIPTION
Hi,

I was testing with the simple producer and consumer, my colleague got confused by the default broker url, as it is not actually used, these 2 patches just remove it.
He tried changing the broker url in the code, and it worked only because he still used the mq-west and mq-east as groups.
Obviously it can only be changed in the jndi.properties file.
